### PR TITLE
change code to use service bus queue instead of event hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ ENV MONGOURL=mongodb://[CosmosDBInstanceName]:[CosmosDBPrimaryPassword]=@[Cosmos
 ENV AMQPURL=amqp://[url]:5672
 ```
 
-### For Event Hubs
+### For Service Bus 
 
 ```
-ENV AMQPURL=amqps://[policy name]:[policy key]@[youreventhub].servicebus.windows.net/[eventhubname]
+ENV AMQPURL=amqps://[policy name]:[policy key]@[yourServiceBus].servicebus.windows.net//[queuename]
 ```
 
 Make sure your _policy key_ is URL Encoded. Use a tool like: <https://www.url-encode-decode.com/>


### PR DESCRIPTION
The code was already using ampq protocol with event hubs, so it is straight forward to replace it with service bus and keep using the same protocol.

I pushed the image to: https://hub.docker.com/r/ilanak/captureorderack/ and test it with my instance of the AKS.